### PR TITLE
Use repo-relative inference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ conda env create -f environment.yml
 We have already prepared some images and masks under 'example' folder. To test the model, you can simply run:
 ```
 python inference.py \
---indir PanoDiffusion/example \
---outdir PanoDiffusion/example/output \
---ckpt PanoDiffusion/pretrain_model/ldm/ldm.ckpt \
---config PanoDiffusion/config/outpainting.yaml \
---refinenet_ckpt PanoDiffusion/pretrain_model/refinenet/refinenet.pth.tar
+--indir ./example \
+--outdir ./example/output \
+--ckpt ./pretrain_model/ldm/ldm.ckpt \
+--config ./config/outpainting.yaml \
+--refinenet_ckpt ./pretrain_model/refinenet/refinenet.pth.tar
 
 or 
 

--- a/inference.sh
+++ b/inference.sh
@@ -1,6 +1,6 @@
 python inference.py \
---indir PanoDiffusion/example \
---outdir PanoDiffusion/example/output \
---ckpt PanoDiffusion/pretrain_model/ldm/ldm.ckpt \
---config PanoDiffusion/config/outpainting.yaml \
---refinenet_ckpt PanoDiffusion/pretrain_model/refinenet/refinenet.pth.tar
+--indir ./example \
+--outdir ./example/output \
+--ckpt ./pretrain_model/ldm/ldm.ckpt \
+--config ./config/outpainting.yaml \
+--refinenet_ckpt ./pretrain_model/refinenet/refinenet.pth.tar


### PR DESCRIPTION
## Summary

The PanoDiffusion example commands assumed they were being run from the parent directory and used paths like `PanoDiffusion/example`. That breaks when running the commands from the repository root.

This PR updates the README example and `inference.sh` to use repo-relative `./...` paths for the example input, output, model checkpoint, config, and refinenet checkpoint.

## Verification

- The original PR did not record a test command.