### PR TITLE
Use the base VQ vector quantizer in autoencoder

### DIFF
--- a/ldm/models/autoencoder.py
+++ b/ldm/models/autoencoder.py
@@ -3,7 +3,7 @@ import pytorch_lightning as pl
 import torch.nn.functional as F
 from contextlib import contextmanager
 
-from taming.modules.vqvae.quantize import VectorQuantizer2 as VectorQuantizer
+from taming.modules.vqvae.quantize import VectorQuantizer as VectorQuantizer
 
 from ldm.modules.diffusionmodules.model import Encoder, Decoder
 from ldm.modules.distributions.distributions import DiagonalGaussianDistribution
@@ -25,8 +25,6 @@ class VQModel(pl.LightningModule):
                  batch_resize_range=None,
                  scheduler_config=None,
                  lr_g_factor=1.0,
-                 remap=None,
-                 sane_index_shape=False, # tell vector quantizer to return indices as bhw
                  use_ema=False
                  ):
         super().__init__()
@@ -36,9 +34,7 @@ class VQModel(pl.LightningModule):
         self.encoder = Encoder(**ddconfig)
         self.decoder = Decoder(**ddconfig)
         self.loss = instantiate_from_config(lossconfig)
-        self.quantize = VectorQuantizer(n_embed, embed_dim, beta=0.25,
-                                        remap=remap,
-                                        sane_index_shape=sane_index_shape)
+        self.quantize = VectorQuantizer(n_embed, embed_dim, beta=0.25)
         self.quant_conv = torch.nn.Conv2d(ddconfig["z_channels"], embed_dim, 1)
         self.post_quant_conv = torch.nn.Conv2d(embed_dim, ddconfig["z_channels"], 1)
         if colorize_nlabels is not None:


### PR DESCRIPTION
## Summary

The autoencoder code did not run in my environment with `VectorQuantizer2` and its extra `remap` / `sane_index_shape` arguments.

This PR switches the import back to the base `VectorQuantizer` and removes the constructor arguments that only applied to the newer quantizer variant.

## Verification

- Verified locally enough to get the code running; the original PR did not record the exact command.